### PR TITLE
feat: basics K8s manifests + hot reload devin k8s with skaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 ## Getting Started
 
+There are two ways to get started:
+
+- [dev] Hot reaload in kubernetes with **skaffold**
+- [local] with **pnpm**
+
+### Skaffold
+
+1. Start by installing Skaffold using this [link](https://skaffold.dev/docs/install/).
+
+2. Set up a local Kubernetes cluster (e.g., using kind):
+
+```bash
+kind create cluster
+```
+
+3. Then, at the root of the project:
+
+```bash
+skaffold dev
+```
+
+4. Port forward the service to access content:
+
+```bash
+kubectl port-forward services/dashboard 3000:80
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+### pnpm
+
 First, install the dependencies:
 
 ```bash

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dashboard
+  name: dashboard
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dashboard
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: dashboard
+    spec:
+      containers:
+      - env:
+        - name: PORT
+          value: "3000"
+        image: ghcr.io/do-22-23-isdm/dashboard
+        name: dashboard
+        resources: {}
+status: {}

--- a/kubernetes/svc.yaml
+++ b/kubernetes/svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dashboard
+  name: dashboard
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: dashboard
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,15 @@
+apiVersion: skaffold/v4beta9
+kind: Config
+metadata:
+  name: dashboard
+build:
+  artifacts:
+    - image: ghcr.io/do-22-23-isdm/dashboard
+      docker:
+        dockerfile: Dockerfile
+  local:
+    useBuildkit: true
+manifests:
+  rawYaml:
+    - kubernetes/deployment.yaml
+    - kubernetes/svc.yaml


### PR DESCRIPTION
This pull request aims to establish basic Kubernetes manifests for development to align with the end environment. This include:

 -  **Kubernetes** manifests
 -  Utilization of **Skaffold** for hot reloading of the base code.

[NOTE]: Skaffold rebuilds the Dockerfile with each code change and redeploys manifests with the updated image locally.